### PR TITLE
fix Pare-Describe-Sync in one packet failed issue

### DIFF
--- a/qinsql-postgresql/src/main/java/org/qinsql/postgresql/server/PgServerConnection.java
+++ b/qinsql-postgresql/src/main/java/org/qinsql/postgresql/server/PgServerConnection.java
@@ -272,6 +272,7 @@ public class PgServerConnection extends AsyncConnection {
                     sendErrorResponse("Prepared not found: " + name);
                 } else {
                     sendParameterDescription(p);
+                    sendNoData();
                 }
             } else if (type == 'P') {
                 Portal p = portals.get(name);
@@ -504,8 +505,8 @@ public class PgServerConnection extends AsyncConnection {
             writeShort(count);
             for (int i = 0; i < count; i++) {
                 int type;
-                if (p.paramType != null && p.paramType[i] != 0) {
-                    type = p.paramType[i];
+                if (meta.getParameterType(i+1) > 0) {
+                    type = PgType.convertType( meta.getParameterType(i+1) );
                 } else {
                     type = PgType.PG_TYPE_VARCHAR;
                 }


### PR DESCRIPTION

sendParameterDescription 之后需要继续发一个NoData
https://github.com/postgres/postgres/blob/b68e356a680ee1155b0dc612a89655e98320121a/src/backend/tcop/postgres.c#L2686C3-L2686C3

type 需要从meta.getParameterType 里拿